### PR TITLE
Agregar plantilla _config.yml.sample

### DIFF
--- a/_config.yml.sample
+++ b/_config.yml.sample
@@ -1,0 +1,9 @@
+name: "Alternativas"
+description: ""
+
+url: "http://<username>.github.io/alternativas.gultij.org/"
+paginate: 10
+
+markdown: rdiscount
+permalink: pretty
+


### PR DESCRIPTION
Se añade la plantilla _config.yml.sample para que el usuario pueda
hacer: cp _config.yml.sample _config.yml y configurar a sus
necesidades.
